### PR TITLE
fix: correctly detect write callback argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,11 @@ function mock(std: 'stdout' | 'stderr'): MockStd {
         writes.push(bufToString(data));
         if (this.print) {
           g['stdout-stderr'][std].apply(process[std], [data, ...args]);
-        } else {
-          const callback = args[0];
-          if (callback) callback();
+        } else if (args.length > 0) {
+          const callback = args[args.length - 1];
+          if (typeof callback === 'function') {
+            callback();
+          }
         }
         return true;
       };

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -35,6 +35,17 @@ describe('stdout', () => {
     stdout.stop();
     expect(called).to.equal(true);
   });
+
+  it('detects the callback argument correctly', () => {
+    let called = false;
+    const mock = () => { called = true; };
+
+    stdout.start();
+    process.stdout.write("data", 'utf-8', () => mock())
+    stdout.stop();
+
+    expect(called).to.equal(true);
+  });
 });
 
 describe('stderr', () => {

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -41,7 +41,7 @@ describe('stdout', () => {
     const mock = () => { called = true; };
 
     stdout.start();
-    process.stdout.write("data", 'utf-8', () => mock())
+    process.stdout.write('data', 'utf-8', () => mock());
     stdout.stop();
 
     expect(called).to.equal(true);


### PR DESCRIPTION
Hello,

I'm currently working with `stdout-stderr` mocks for testing in NodeJS and I ran into an issue.

Here is a minimal reproducible example:
```ts
import { stdout } from 'stdout-stderr';

stdout.start();
process.stdout.write('data', 'utf-8');
stdout.stop();
```

When I run this code I get an error saying `TypeError: callback is not a function` pointing me to this line
https://github.com/jdxcode/stdout-stderr/blob/7cf3d41e7e61193a78088934a6c9d141bf149411/src/index.ts#L56

It looks like the code doesn't take into account the `write(data, encoding, cb)` overload that I'm calling.

This PR fixes that by looking for the callback at the end of the argument list and does an additional function typecheck.